### PR TITLE
Fix issue with regex check + missing outputs in v2.6.0

### DIFF
--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -328,7 +328,7 @@ jobs:
           echo "OUTPUT_URL=$OUTPUT_URL" >> $GITHUB_ENV
           echo "OUTPUT_CONTAINERS=$OUTPUT_CONTAINERS" >> $GITHUB_ENV
 
-          export EXPIRATION_HOURS=$(grep --perl-regexp --only-matching 'delete_preview_after: \K\d+' ${{ inputs.compose-file-cache-path }})
+          export EXPIRATION_HOURS=$(grep --perl-regexp --only-matching '^[ \t]*(?!#)delete_preview_after: \K\d+' ${{ inputs.compose-file-cache-path }})
           if [ -z "$EXPIRATION_HOURS" ]
           then
             echo "No preview expiration parameter found."

--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -86,6 +86,9 @@ on:
       id:
         description: "Uffizzi Preview Deployment ID"
         value: ${{ jobs.uffizzi-preview.outputs.id }}
+      containers_uri:
+        description: 'URL to Uffizzi Deployment Details'
+        value: ${{ jobs.uffizzi-preview.outputs.containers_uri }}
       expiration_interval:
         description: "Uffizzi Preview Expiration Interval in Seconds"
         value: ${{ jobs.uffizzi-preview.outputs.expiration_interval }}
@@ -105,6 +108,7 @@ jobs:
     outputs:
       url: ${{ steps.outputs.outputs.url }}
       id: ${{ steps.outputs.outputs.id }}
+      containers_uri: ${{ steps.outputs.outputs.containers_uri }}
       expiration_interval: ${{ steps.outputs.outputs.expiration_interval }}
       expiration: ${{ steps.outputs.outputs.expiration }}
     steps:

--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -103,8 +103,11 @@ on:
         description: "Uffizzi Preview Expiration Interval in Seconds"
         value: ${{ jobs.uffizzi-preview.outputs.expiration_interval }}
       expiration:
-        description: "Uffizzi Preview Expiration Timestamp String"
+        description: "Uffizzi Preview Expiration Time String"
         value: ${{ jobs.uffizzi-preview.outputs.expiration }}
+      expiration_timestamp:
+        description: "Uffizzi Preview Expiration UNIX Timestamp"
+        value: ${{ jobs.uffizzi-preview.outputs.expiration_timestamp }}
 
 permissions:
   contents: read
@@ -121,6 +124,7 @@ jobs:
       containers_uri: ${{ steps.outputs.outputs.containers_uri }}
       expiration_interval: ${{ steps.outputs.outputs.expiration_interval }}
       expiration: ${{ steps.outputs.outputs.expiration }}
+      expiration_timestamp: ${{ steps.outputs.outputs.expiration_timestamp }}
     steps:
       - name: DEBUG - Dump GitHub context and environment info
         if: ${{ runner.debug }}
@@ -334,7 +338,8 @@ jobs:
             echo "No preview expiration parameter found."
           else
             export EXPIRATION_INTERVAL=$(( $EXPIRATION_HOURS * 3600 ))
-            export EXPIRATION=$(date --utc --date=@$(($(date +'%s') + $EXPIRATION_INTERVAL)))
+            export EXPIRATION_TIMESTAMP=$(date +'%s')
+            export EXPIRATION=$(date --utc --date=@$(($EXPIRATION_TIMESTAMP + $EXPIRATION_INTERVAL)))
 
             echo "Expiring in $EXPIRATION_INTERVAL seconds at $EXPIRATION."
 
@@ -348,6 +353,7 @@ jobs:
           echo "containers_uri=$OUTPUT_CONTAINERS" >> $GITHUB_OUTPUT
           echo "expiration_interval=$EXPIRATION_INTERVAL" >> $GITHUB_OUTPUT
           echo "expiration=$EXPIRATION" >> $GITHUB_OUTPUT
+          echo "expiration_timestamp=$EXPIRATION_TIMESTAMP" >> $GITHUB_OUTPUT
 
       - name: Create or Update Comment with Deployment URL
         uses: peter-evans/create-or-update-comment@v2

--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -339,7 +339,7 @@ jobs:
             echo "Expiring in $EXPIRATION_INTERVAL seconds at $EXPIRATION."
 
             echo "EXPIRATION_INTERVAL=$EXPIRATION_INTERVAL" >> $GITHUB_ENV
-            echo "EXPIRATION=This Preview will be destroyed in $EXPIRATION_HOURS hours at: $EXPIRATION" >> $GITHUB_ENV
+            echo "EXPIRATION=:alarm_clock: This Preview will be destroyed in $EXPIRATION_HOURS hours at: $EXPIRATION" >> $GITHUB_ENV
           fi
 
           # Expose the step output variables
@@ -362,7 +362,7 @@ jobs:
 
             :page_facing_up: [View Application Logs etc.](${{ env.OUTPUT_CONTAINERS }})
 
-            :alarm_clock: ${{ env.EXPIRATION }}
+            ${{ env.EXPIRATION }}
 
             What is Uffizzi? [Learn more](https://github.com/UffizziCloud/uffizzi)
           edit-mode: replace

--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -342,6 +342,13 @@ jobs:
             echo "EXPIRATION=This Preview will be destroyed in $EXPIRATION_HOURS hours at: $EXPIRATION" >> $GITHUB_ENV
           fi
 
+          # Expose the step output variables
+          echo "url=$OUTPUT_URL" >> $GITHUB_OUTPUT
+          echo "id=$OUTPUT_ID" >> $GITHUB_OUTPUT
+          echo "containers_uri=$OUTPUT_CONTAINERS" >> $GITHUB_OUTPUT
+          echo "expiration_interval=$EXPIRATION_INTERVAL" >> $GITHUB_OUTPUT
+          echo "expiration=$EXPIRATION" >> $GITHUB_OUTPUT
+
       - name: Create or Update Comment with Deployment URL
         uses: peter-evans/create-or-update-comment@v2
         if: ${{ inputs.compose-file-cache-key != '' }}

--- a/action.yaml
+++ b/action.yaml
@@ -90,7 +90,9 @@ outputs:
   expiration_interval:
     description: "Expiration interval in seconds"
   expiration:
-    description: 'Expiration timestamp as a string'
+    description: 'Expiration as a string'
+  expiration_timestamp:
+    description: 'Expiration as a UNIX timestamp'
 runs:
   using: 'docker'
   image: 'docker://uffizzi/cli:v1'

--- a/action.yaml
+++ b/action.yaml
@@ -87,6 +87,10 @@ outputs:
     description: 'ID of preview for later reference'
   containers_uri:
     description: 'URI to the deployment details'
+  expiration_interval:
+    description: "Expiration interval in seconds"
+  expiration:
+    description: 'Expiration timestamp as a string'
 runs:
   using: 'docker'
   image: 'docker://uffizzi/cli:v1'


### PR DESCRIPTION
In v2.6.0, the regex check was added for `delete_preview_after`, which would populate the `EXPIRATION_HOURS` variable with the expiration hours value.

However, this regex check did not take into account commented out lines in a Docker Compose file, which meant that not only would this work incorrectly when ran, but if there were multiple commented out entries with a matching line/value, it would return every commented out result, such as the following:
```yaml
  ...
  #   # delete_preview_after: 1h
  #   # delete_preview_after: 24h
  #   delete_preview_after: 72h
  ...
```

The example above would cause the workflow to fail with the following:
```
/home/runner/work/_temp/cd737192-c615-47af-8150-73e1d6c4ef3a.sh: line 23: 1
24
72 * 3600 : syntax error in expression (error token is "24
72 * 3600 ")
```

This proposed regex change will still return all results, however since it now also ignores commented out lines, this shouldn't matter and should purely be user error, in case the user is defining the same values two (or more) times per compose file.

## UPDATE

I additionally noticed that PR #35 seems to have broken more than it has fixed, and I'm not quite sure what the idea was with replacing the already working logic with environment variables.

The PR mentioned above removed the deprecated `set-output` method of defining outputs, however it never implemented the new way of creating outputs, which means that the reusable workflow no longer exports any of the outputs.

I made an additional commit that fixes this, but I would advise rewriting/refactoring the entire workflow file, as the order of the jobs/steps, as well as the now even more unnecessarily complex dependency, variable and output logic, are all making it that much harder to find issues in and to improve in the future.

NOTE: In addition to fixing this, I also added `expiration` and `expiration_interval` to the actual action's outputs, however I'm not sure if these are currently being exported by the action itself. So just FYI.

EDIT: Also added `expiration_timestamp` in UNIX timestamp format, as this is the most versatile and useful option when integrating with other services and workflows.