### PR TITLE
fix: use git-ref again at "Checkout commit" step

### DIFF
--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -255,7 +255,7 @@ jobs:
         if: ${{ contains(fromJSON('["create", "update"]'), env.UFFIZZI_ACTION) }}
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.git-ref || github.event.pull_request.head.sha }}
 
       - name: Fetch cached Compose File
         id: cache


### PR DESCRIPTION
At release 2.6.3, a regression for the `git-ref` input introduced in 2.6.0 was introduced replacing it with the use of the PR head sha from the PR event payload.

Originally, `git-ref` was introduced to support the case when the action is triggered by another workflow and not a PR event.

The change will use the input again.

Also, the `git-ref` will have precedence over
the PR head sha as this is a user-passed argument and should be used even in case the PR head sha is available.

Closes: #72