### PR TITLE
Fix yaml syntax

### DIFF
--- a/.github/workflows/reusable.yaml
+++ b/.github/workflows/reusable.yaml
@@ -48,7 +48,7 @@ on:
         default: 'What is Uffizzi? [Learn more](https://www.uffizzi.com)!'
         required: false
         type: string
-     environment:
+      environment:
         description: 'Custom environment for the deployed preview'
         default: 'uffizzi'
         required: false


### PR DESCRIPTION
Fixes yaml spacing syntax from https://github.com/UffizziCloud/preview-action/pull/74. It contained incorrect yaml spacing, causing yaml syntax parse errors when trying to call this action.